### PR TITLE
Changes to child nodes and node parenting

### DIFF
--- a/py_rpg/core/node.py
+++ b/py_rpg/core/node.py
@@ -10,51 +10,48 @@ class Node:
                  parent: Optional["Node"] = None) -> None:
         self.name = node_name
         self.__parent: "Node" | None = None
-        self.parent = parent
-        self.child_nodes: list["Node"] = []
+        if parent:
+            parent.add_child(self)
+        self.child_nodes: dict[str, "Node"] = {}
 
     @property
     def parent(self) -> Optional["Node"]:
         return self.__parent
 
-    @parent.setter
-    def parent(self, value: Optional["Node"]) -> None:
-        if self.__parent is not None:
-            self.__parent.child_nodes.remove(self)
-        self.__parent = value
-        if value is None:
-            return
-        value.add_child(self)
-
     def add_child(self, node: "Node") -> None:
         """Adds a child object to the Node.
         
         :raises TypeError: Argument is not a subclass of Node
+        :raises RuntimeError: Node already has a parent
         """
         if not issubclass(type(node), Node):
             raise TypeError
-        self.child_nodes.append(node)
+        if node.parent is not None:
+            raise RuntimeError
+        node_name: str = node.name
+        self.child_nodes[node_name] = node
         node.__parent = self
 
-    def remove_child(self, idx: int) -> "Node":
-        """Removes and returns a child object at given index.
+    def remove_child(self, node_name: str) -> Optional["Node"]:
+        """Removes and returns a child object with a given name, or None if not found.
+        Sets child node's parent to None.
         
-        :returns: Node
-        :raises IndexError: Given index is invalid
+        :returns: Node | None
         """
-        return self.child_nodes.pop(idx)
+        node = self.child_nodes.pop(node_name, None)
+        if node:
+            node.__parent = None
+        return node
 
-    def find_child(self, name: str) -> Optional["Node"]:
+    def find_child(self, node_name: str) -> Optional["Node"]:
         """Finds and returns a child object with a given name.
         
         Only returns the first object with a matching name, or None if no matches found.
 
-        :returns: Node or None
+        :returns: Node | None
         """
-        for child in self.child_nodes:
-            if child.name != name:
-                continue
-            return child
+        if node_name in self.child_nodes:
+            return self.child_nodes[node_name]
         return None
 
     def update(self) -> None:

--- a/py_rpg/game.py
+++ b/py_rpg/game.py
@@ -83,7 +83,7 @@ class Game:
         return self.__debug_mode
 
     def __get_player_input(self) -> None:
-        player = self.__characters.child_nodes[0]
+        player = self.__characters.child_nodes["Player"]
         if not isinstance(player, Character):
             return
         mouse_position = pyray.get_mouse_position()
@@ -101,7 +101,7 @@ class Game:
             player.move_to(mouse_world_position)
         # Check who's under the cursor when pressing the right mouse button
         if pyray.is_mouse_button_pressed(1):
-            for character in self.__characters.child_nodes:
+            for character in self.__characters.child_nodes.values():
                 if not type(character) is Character:
                     continue
                 rec = pyray.Rectangle(character.pos_x, character.pos_y, TILE_SIZE, TILE_SIZE)
@@ -111,7 +111,7 @@ class Game:
                     break
 
     def __update_node_recursive(self, node: Node, update_renderables: bool) -> None:
-        for child in node.child_nodes:
+        for child in node.child_nodes.values():
             self.__update_node_recursive(child, update_renderables)
         if update_renderables and isinstance(node, RenderableNode):
             self.__renderables.append(node)
@@ -145,7 +145,7 @@ class Game:
 
     def run(self) -> None:
         # TODO: Delete these after testing
-        chr = self.__characters.child_nodes[1]
+        chr = self.__characters.child_nodes["Mike"]
         if isinstance(chr, Character):
             new_position = pyray.Vector2(chr.pos_x + 128, chr.pos_y + 64)
             chr.move_to(new_position)


### PR DESCRIPTION
Child nodes are now stored in dict instead of a list.

A Node no longer can be parented via parent.setter. Instead, parent can only be altered via Node.add_child() and Node.remove_child. Node.add_child() no longer accepts nodes that already have a parent.